### PR TITLE
Specify username for partial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ consul {
 provider "panos" {
   alias = "panos1" 
   hostname = "<panos_address>" # eg. "2.2.2.2"
+  username = "<admin_username>" # Username the API key is associated with for partial commit
   api_key  = "<api_key>" 
 }
 


### PR DESCRIPTION
## Description

Add documentation to include the newly required admin username in the panos provider block configuration.

## Motivation and Context

Consul-Terraform-Sync supports auto-committing after Terraform apply. However, using the API key it defaults to committing all changes, including changes made by other users. For Consul-Terraform-Sync to support partial commits, changes were made to require the username the key is associated with https://github.com/hashicorp/consul-terraform-sync/pull/137

## How Has This Been Tested?

Cases tested with NGFW v9.1.3:

* api key (no username): Consul-Terraform-Sync validation error on startup
* api key + associated username: changes committed
* api key + associated username + changes by another user: only user's changes are committed
* api key + different username: no-op commit, changes made by the token are not committed because commit is looking for changes by another username.
* api key + non-existing username: same as above
* api key + different username with changes from that user: edge case it will auto-commit for that user and not the changes made by the token and its user.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
